### PR TITLE
Fix: Resolved duplicate initial prompt in Terminal Contact.

### DIFF
--- a/src/components/sections/TerminalContact.jsx
+++ b/src/components/sections/TerminalContact.jsx
@@ -23,6 +23,7 @@ export default function TerminalContact() {
     { type: 'system', text: '─────────────────────────────' },
     { type: 'system', text: 'Type your response after each prompt and press Enter.' },
     { type: 'system', text: '' },
+    { type: 'prompt', text: PROMPTS[0].prompt },
   ]);
   const [submitted, setSubmitted] = useState(false);
   const [formData, setFormData] = useState({});
@@ -43,15 +44,6 @@ export default function TerminalContact() {
     }
   }, [isInView, step, submitted]);
 
-  // Show first prompt on mount
-  useEffect(() => {
-    if (step === 0 && !submitted) {
-      setHistory((h) => [
-        ...h,
-        { type: 'prompt', text: PROMPTS[0].prompt },
-      ]);
-    }
-  }, []);
 
   const handleSubmitLine = useCallback(
     (e) => {


### PR DESCRIPTION
This change eliminates the issue where "Enter your name" appeared twice upon loading the terminal.

•Cause: The prompt was being added once by the initial history state and a second time by a useEffect hook firing on mount.

•Solution: Moved the first prompt into the initial state definition and removed the unnecessary useEffect logic.

•Result: The terminal now correctly displays the system header followed by a single input prompt.
BEFORE:-
<img width="1920" height="1020" alt="Screenshot 2026-03-28 131925" src="https://github.com/user-attachments/assets/b7aba2cc-8118-49c8-8193-88ea22470296" />
AFTER:-
<img width="1920" height="1020" alt="Screenshot 2026-03-28 010102" src="https://github.com/user-attachments/assets/879c6852-dcaf-4ea5-9a1a-1208ade7cee4" />
